### PR TITLE
type-alias

### DIFF
--- a/type-script-lesson/anyType.ts
+++ b/type-script-lesson/anyType.ts
@@ -1,0 +1,10 @@
+// anyタイプは何でも入れれる
+// anyタイプに間れするコードはJSに戻る
+let anything: any = true;
+
+anything = 'hello'
+anything = 123123;
+
+let banana = 'banana'
+banana = anything
+

--- a/type-script-lesson/enumStudy.ts
+++ b/type-script-lesson/enumStudy.ts
@@ -1,0 +1,28 @@
+// ENUM
+enum CoffeeSize {
+    SHORT = 'SHORT',
+    TALL = 'TALL',
+    GRANDE = 'GRANDE',
+    VENTI = 'VENTI'
+}
+
+const coffee: {
+    hot: boolean,
+    size: CoffeeSize
+} = {
+    hot: true,
+    size: CoffeeSize.TALL
+}
+
+coffee.size = CoffeeSize.VENTI
+
+console.log(coffee)
+
+// enumに関してはすべて大文字をで書こう
+enum NoTypeEnum {
+    ONE,    // 0 
+    TWO,    // 0
+    THREE   // 0
+}
+const val = NoTypeEnum.ONE
+console.log(val)

--- a/type-script-lesson/literalType.ts
+++ b/type-script-lesson/literalType.ts
@@ -1,0 +1,31 @@
+// literal type : 特定の決まった値のみを扱う型
+let apple : 'apple' = 'apple';
+// apple = 'banana';　＝ エラー
+// appleというリテラル型しか扱わない。
+
+///////////////////////////////
+// zero = 2; 0というリテラル型のデータしか代入できない
+let zero: 0 = 0;
+
+enum ClothSize {
+    small = 'SHORT',
+    TALL = 'TALL',
+    GRANDE = 'GRANDE',
+    VENTI = 'VENTI'
+}
+
+let clothSize : ClothSize = ClothSize.small;
+let clothSize2 : ClothSize = ClothSize.GRANDE;
+
+let clothSize3: 'small' | 'medium' | 'large' = "small";
+
+
+let cloths: {
+    color: string
+    size: ClothSize
+} = {
+    color:　'red',
+    size: ClothSize.GRANDE
+};
+
+cloths.color = 'red';

--- a/type-script-lesson/typeAlias.js
+++ b/type-script-lesson/typeAlias.js
@@ -1,0 +1,6 @@
+var size;
+size = 'medium';
+var cloth = {
+    color: 'red',
+    size: 'medium'
+};

--- a/type-script-lesson/typeAlias.ts
+++ b/type-script-lesson/typeAlias.ts
@@ -1,0 +1,16 @@
+// タイプエイリアス：型を変数のように使う
+// エイリアス　＝　別名
+// small medium largeという型をClothSizeという変数として扱う
+type ClothSizeEnum = 'small' | 'medium' | 'large';
+
+let　size: ClothSizeEnum;
+
+size = 'medium'
+
+const cloth: {
+    color: string;
+    size: ClothSizeEnum
+} = {
+    color : 'red',
+    size : 'medium'
+}

--- a/type-script-lesson/unionType.ts
+++ b/type-script-lesson/unionType.ts
@@ -1,0 +1,17 @@
+// 定められた型しか代入できない
+// 
+let unionType: number | string;
+unionType = 1;
+unionType = 'dwada'
+unionType.toLowerCase()
+// unionType = true //　タイプエラー
+
+// 配列でユニオンタイプを使うとき
+// 配列では複数のタイプを指定することができる。
+// 下記のコードはナンバー文字ブーリアンタイプのデータを
+// 保存することができる
+let unionTypes: (number | string | boolean)[] = [];
+
+unionTypes.push(1)
+unionTypes.push('fawdas')
+


### PR DESCRIPTION
// タイプエイリアス：型を変数のように使う
// エイリアス　＝　別名
// small medium largeという型をClothSizeという変数として扱う
`type ClothSizeEnum = 'small' | 'medium' | 'large';

let　size: ClothSizeEnum;

size = 'medium'

const cloth: {
    color: string;
    size: ClothSizeEnum
} = {
    color : 'red',
    size : 'medium'
}`