### PR TITLE
include-exclude-files setting

### DIFF
--- a/section03/compiler.js
+++ b/section03/compiler.js
@@ -1,8 +1,0 @@
-"use strict";
-// tsc --init tsconfig.json을 만들어 
-// 모든 ts파일을 일괄 컴파일을 진행하자
-// 1. tsc --init을 입력하여 tsconfig.json을 생성
-// 2. tsc만 입력해도 모든 TS파일은 JS파일로 컴파일된다.
-// 지정해서 한꺼번에 컴파일하는 방법 
-// => 예) tsc index.ts index2.ts
-console.log("compile");

--- a/section03/tmp/compiler.js
+++ b/section03/tmp/compiler.js
@@ -1,14 +1,14 @@
+"use strict";
 // tsc --init tsconfig.json을 만들어 
 // 모든 ts파일을 일괄 컴파일을 진행하자
 // 1. tsc --init을 입력하여 tsconfig.json을 생성
 // 2. tsc만 입력해도 모든 TS파일은 JS파일로 컴파일된다.
-
 // 지정해서 한꺼번에 컴파일하는 방법 
 // => 예) tsc index.ts index2.ts
-
 // tsc를 입력하면 tsconfig.json을 토대로 컴파일이 된다. 
 // 현재 이 폴더에 존재하는 tsconfig.json은 "target": "es2016" 로 설정되어있기때문에 
 // 컴파일을 하면 var타입은 안나오고 let const로 컴파일이 된다. 
 // 하지만 tsc index.ts와 같이 하게되면 tsconfig.json은 적용되지 않아 
 // 예날의 JS의 문법으로 바뀐다. 
-console.log("compile")
+console.log("compile");
+console.log("files확인");

--- a/section03/tmp/compiler.ts
+++ b/section03/tmp/compiler.ts
@@ -1,0 +1,15 @@
+// tsc --init tsconfig.json을 만들어 
+// 모든 ts파일을 일괄 컴파일을 진행하자
+// 1. tsc --init을 입력하여 tsconfig.json을 생성
+// 2. tsc만 입력해도 모든 TS파일은 JS파일로 컴파일된다.
+
+// 지정해서 한꺼번에 컴파일하는 방법 
+// => 예) tsc index.ts index2.ts
+
+// tsc를 입력하면 tsconfig.json을 토대로 컴파일이 된다. 
+// 현재 이 폴더에 존재하는 tsconfig.json은 "target": "es2016" 로 설정되어있기때문에 
+// 컴파일을 하면 var타입은 안나오고 let const로 컴파일이 된다. 
+// 하지만 tsc index.ts와 같이 하게되면 tsconfig.json은 적용되지 않아 
+// 예날의 JS의 문법으로 바뀐다. 
+console.log("compile")
+console.log("files확인")

--- a/section03/tsconfig.json
+++ b/section03/tsconfig.json
@@ -104,5 +104,22 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [  // 어떤 파일을 컴파일 할지 명시적으로 설정
+    "watchMode.ts"
+  ],
+  // exclude : 전체 컴파일대상군에서 제외할 TS파일을 설정
+  "exclude": [
+    "**/compiler.ts",
+    // "tmp/compiler.ts", // root dir를 기준으로 제외대상으로 인식한다. 
+    // **/compiler.ts 어떤 폴더에 있더라도 컴파일대상에서 제외하고 싶다면 **/compiler.ts로 설정을 하면 된다.
+    "*.spec.ts", // * : 임의 .spec.ts는 모드 컴파일대상에서 제외된다.
+    "node_modules"  // npm으로 인스톨된 패키지들이 node_modules안에 들어간다.
+  ],
+  // exclude안에 정의된 파일도 files에 정의 되어있으면 JS로 커마일이 가능하다
+  "files": [  // *는 못쓰고 절대경로와 상대경로만 써야한다.
+    "tmp/compiler.ts"
+  ]
+
 }
+


### PR DESCRIPTION
`
  "include": [  // 어떤 파일을 컴파일 할지 명시적으로 설정
    "watchMode.ts"
  ],
  // exclude : 전체 컴파일대상군에서 제외할 TS파일을 설정
  "exclude": [
    "**/compiler.ts",
    // "tmp/compiler.ts", // root dir를 기준으로 제외대상으로 인식한다. 
    // **/compiler.ts 어떤 폴더에 있더라도 컴파일대상에서 제외하고 싶다면 **/compiler.ts로 설정을 하면 된다.
    "*.spec.ts", // * : 임의 .spec.ts는 모드 컴파일대상에서 제외된다.
    "node_modules"  // npm으로 인스톨된 패키지들이 node_modules안에 들어간다.
  ],
  // exclude안에 정의된 파일도 files에 정의 되어있으면 JS로 커마일이 가능하다
  "files": [  // *는 못쓰고 절대경로와 상대경로만 써야한다.
    "tmp/compiler.ts"
  ]
`