### PR TITLE
strict-setting

### DIFF
--- a/section03/src/tmp/compiler.ts
+++ b/section03/src/tmp/compiler.ts
@@ -18,6 +18,19 @@ function add(n1: number, n2: number): number {
     return n1 + n2;
 }
 
+//"strictNullChecks": trueに設定したら下の四つのコードはすべてエラーになる
+// let nullAble: string = null;
+// let undefinedAble: string = undefined;
+// let onlyNull: null = undefined;
+// let onlyUndefined: undefined = null;
+
+
+
 // "noEmitOnError" : trueと設定すると
 //　エラーが起きた場合JSにコンパイルされない
-add(hi, 12)
+// add(hi, 12)
+
+// "noImplicitAny": true =>　暗黙的なanyはエラーを起こす
+function echo(mess: string) {
+    return mess;
+}

--- a/section03/tsconfig.json
+++ b/section03/tsconfig.json
@@ -82,20 +82,20 @@
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    // "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strict": true,   //　strict:trueにしたらstrictから下の８番目までtrueに設定される                                   /* Enable all strict type-checking options. */
+    // "noImplicitAny": true, // 暗黙的なanyはエラーを出す   /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,   // 厳しいnullチェック          /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true, // クラスの継承時得るバグを防ぐ            /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true, //コンパイルされたJSファイルが常にuse strictを使用する設定  /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "noImplicitThis": true,  thisがいったん何を示しているのかわからない時にエラーを起こす   /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "alwaysStrict": true,                            /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */


### PR DESCRIPTION
"noImplicitAny": true, // 暗黙的なanyはエラーを出す
"strictNullChecks": true,   // 厳しいnullチェック
"strictFunctionTypes": true, // クラスの継承時得るバグを防ぐ
strictBindCallApply": true, //コンパイルされたJSファイルが常にuse strictを使用する設定
"noImplicitThis": true,  thisがいったん何を示しているのかわからない時にエラーを起こす