### PR TITLE
key operator

### DIFF
--- a/section07/src/keyOperator.ts
+++ b/section07/src/keyOperator.ts
@@ -1,0 +1,16 @@
+// key operator
+// objectの型について使用
+// keyを型にする
+type K = keyof { name: string; age: number}
+
+let kVal: K;
+kVal = "age"
+kVal = "name"
+
+// extends keyofとは
+function copy3<T extends { name: string }, U extends keyof T>(value: T, key: U): T {
+    value[key]
+    return value
+}
+
+copy({ name: "taki", age: 39})


### PR DESCRIPTION
objectの型について使用
keyを型にする

extends keyofとは
function copy3<T extends { name: string }, U extends keyof T>(value: T, key: U): T {
    value[key]
    return value
}